### PR TITLE
feat: extend the built-in release note template to include the wrapped commit body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tera",
+ "textwrap",
 ]
 
 [[package]]
@@ -1085,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1161,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,10 +1200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1.11.1"
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 tera = "1.20.0"
+textwrap = "0.16"
 
 [build-dependencies]
 built = { version = "0.8.0", features = ["git2", "semver", "chrono"] }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,10 +1,16 @@
 use crate::analyzer::{CategorizedCommits, CommitCategory};
 use anyhow::{Context, Result};
+use std::collections::HashMap;
+use tera::Value;
 
 pub const TEMPLATE: &str = r#"{%- if breaking %}
 ## Breaking Changes
 {%- for commit in breaking %}
 - {{ commit.hash }} {{ commit.first_line }}
+{%- if commit.body %}
+
+{{ commit.body | wrap(width=80) | indent(prefix = "  ", first=true) }}
+{%- endif %}
 {%- endfor %}
 
 {%- endif %}
@@ -12,6 +18,10 @@ pub const TEMPLATE: &str = r#"{%- if breaking %}
 ## New Features
 {%- for commit in features %}
 - {{ commit.hash }} {{ commit.first_line }}
+{%- if commit.body %}
+
+{{ commit.body | wrap | indent(prefix = "  ", first=true) }}
+{%- endif %}
 {%- endfor %}
 
 {%- endif %}
@@ -19,6 +29,10 @@ pub const TEMPLATE: &str = r#"{%- if breaking %}
 ## Bug Fixes
 {%- for commit in fixes %}
 - {{ commit.hash }} {{ commit.first_line }}
+{%- if commit.body %}
+
+{{ commit.body | wrap | indent(prefix = "  ", first=true) }}
+{%- endif %}
 {%- endfor %}
 
 {%- endif %}
@@ -26,16 +40,36 @@ pub const TEMPLATE: &str = r#"{%- if breaking %}
 ## Dependency Updates
 {%- for commit in dependencies %}
 - {{ commit.hash }} {{ commit.first_line }}
+{%- if commit.body %}
+
+{{ commit.body | wrap | indent(prefix = "  ", first=true) }}
+{%- endif %}
 {%- endfor %}
 
 {%- endif %}
 
 *Generated with [release-note](https://github.com/purpleclay/release-note)*"#;
 
+fn wrap_filter(value: &Value, args: &HashMap<String, Value>) -> tera::Result<Value> {
+    let text = value
+        .as_str()
+        .ok_or_else(|| tera::Error::msg("wrap filter requires a string value"))?;
+
+    let width = args.get("width").and_then(|v| v.as_u64()).unwrap_or(80) as usize;
+
+    let (unwrapped, _) = textwrap::unfill(text);
+
+    let options = textwrap::Options::new(width);
+    let wrapped = textwrap::fill(&unwrapped, options);
+    Ok(Value::String(wrapped))
+}
+
 pub fn render_history(categorized: &CategorizedCommits) -> Result<String> {
     let mut tera = tera::Tera::default();
     tera.add_raw_template("main", TEMPLATE)
         .context("failed to parse template")?;
+
+    tera.register_filter("wrap", wrap_filter);
 
     let mut context = tera::Context::new();
 


### PR DESCRIPTION
closes #42