### PR TITLE
feat: add a strip_conventional_prefix tera filter to support removal of commit prefixes in template

### DIFF
--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -11,9 +11,14 @@ fn generates_release_note_from_multiple_categories() {
 
     by_category.insert(
         CommitCategory::Breaking,
-        vec![CommitBuilder::new("feat!: the course of true love never did run smooth")
-            .with_body("Lord, what fools these mortals be! The lunatic, the lover and the poet are of imagination all compact.")
-            .build()],
+        vec![
+            CommitBuilder::new("feat!: the course of true love never did run smooth")
+                .with_body("Lord, what fools these mortals be! The lunatic, the lover and the poet are of imagination all compact.")
+                .build(),
+            CommitBuilder::new("refactor(york)!: now is the winter of our discontent")
+                .with_body("BREAKING CHANGE: made glorious summer by this sun of York.")
+                .build(),
+        ],
     );
 
     by_category.insert(

--- a/tests/snapshots/markdown__displays_multiple_contributors.snap
+++ b/tests/snapshots/markdown__displays_multiple_contributors.snap
@@ -3,7 +3,7 @@ source: tests/markdown.rs
 expression: result
 ---
 ## New Features
-- f7195de64b75eee5f7195de64b75eee5f7195de6 feat: we are such stuff as dreams are made on (@shakespeare, @marlowe, @jonson)
-- c82cb9580ca797b8c82cb9580ca797b8c82cb958 feat: some Cupid kills with arrows, some with traps (@shakespeare)
+- f7195de64b75eee5f7195de64b75eee5f7195de6 we are such stuff as dreams are made on (@shakespeare, @marlowe, @jonson)
+- c82cb9580ca797b8c82cb9580ca797b8c82cb958 some Cupid kills with arrows, some with traps (@shakespeare)
 
 *Generated with [release-note](https://github.com/purpleclay/release-note)*

--- a/tests/snapshots/markdown__excludes_git_trailers.snap
+++ b/tests/snapshots/markdown__excludes_git_trailers.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/markdown.rs
-assertion_line: 111
 expression: result
 ---
 ## New Features
-- 2c834bf8cfb379582c834bf8cfb379582c834bf8 feat: the lady doth protest too much, methinks
+- 2c834bf8cfb379582c834bf8cfb379582c834bf8 the lady doth protest too much, methinks
 
   Though this be madness, yet there is method in't.
-- 51eafb29bc0a294f51eafb29bc0a294f51eafb29 feat: brevity is the soul of wit
+- 51eafb29bc0a294f51eafb29bc0a294f51eafb29 brevity is the soul of wit
 
   To be, or not to be, that is the question:
   - Whether 'tis nobler in the mind to suffer
@@ -15,7 +14,7 @@ expression: result
 
   Or to take arms against a sea of troubles.
 ## Bug Fixes
-- 57b850ba6d18ab8157b850ba6d18ab8157b850ba fix: something is rotten in the state of Denmark
+- 57b850ba6d18ab8157b850ba6d18ab8157b850ba something is rotten in the state of Denmark
 
   The rest is silence.
 

--- a/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
+++ b/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
@@ -3,19 +3,22 @@ source: tests/markdown.rs
 expression: result
 ---
 ## Breaking Changes
-- 4cfa67f04adbe4244cfa67f04adbe4244cfa67f0 feat!: the course of true love never did run smooth
+- 4cfa67f04adbe4244cfa67f04adbe4244cfa67f0 the course of true love never did run smooth
 
   Lord, what fools these mortals be! The lunatic, the lover and the poet are of imagination all compact.
+- b0a136dca8442f6cb0a136dca8442f6cb0a136dc now is the winter of our discontent
+
+  BREAKING CHANGE: made glorious summer by this sun of York.
 ## New Features
-- 8c8a505c3365cb6c8c8a505c3365cb6c8c8a505c feat: all the world's a stage
+- 8c8a505c3365cb6c8c8a505c3365cb6c8c8a505c all the world's a stage
 
   And all the men and women merely players. They have their exits and their entrances; and one man in his time plays many parts.
-- 70204b7eaa8fbf4070204b7eaa8fbf4070204b7e feat: to be or not to be
+- 70204b7eaa8fbf4070204b7eaa8fbf4070204b7e to be or not to be
 ## Bug Fixes
-- fd0ff5c9d7cd4bf9fd0ff5c9d7cd4bf9fd0ff5c9 fix: though she be but little, she is fierce
+- fd0ff5c9d7cd4bf9fd0ff5c9d7cd4bf9fd0ff5c9 though she be but little, she is fierce
 
   Some are born great, some achieve greatness, and some have greatness thrust upon them.
 ## Dependency Updates
-- 7c555da727251e1b7c555da727251e1b7c555da7 fix(deps): the better part of valor is discretion
+- 7c555da727251e1b7c555da727251e1b7c555da7 the better part of valor is discretion
 
 *Generated with [release-note](https://github.com/purpleclay/release-note)*

--- a/tests/snapshots/markdown__handles_mixed_structured_content.snap
+++ b/tests/snapshots/markdown__handles_mixed_structured_content.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 274
 expression: result
 ---
 ## New Features
-- 02b437dcc3be9b7b02b437dcc3be9b7b02b437dc feat: comprehensive guide to staging Hamlet
+- 02b437dcc3be9b7b02b437dcc3be9b7b02b437dc comprehensive guide to staging Hamlet
 
   This production combines the traditional elements of Elizabethan theatre with modern interpretations:
 

--- a/tests/snapshots/markdown__preserves_block_quotes_as_is.snap
+++ b/tests/snapshots/markdown__preserves_block_quotes_as_is.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 195
 expression: result
 ---
 ## New Features
-- 1802980fdd17481c1802980fdd17481c1802980f feat: add wisdom from the bard
+- 1802980fdd17481c1802980fdd17481c1802980f add wisdom from the bard
 
   From the great playwright's most celebrated work on the nature of existence:
 

--- a/tests/snapshots/markdown__preserves_code_blocks_without_wrapping.snap
+++ b/tests/snapshots/markdown__preserves_code_blocks_without_wrapping.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 172
 expression: result
 ---
 ## New Features
-- e313b4f0ab857239e313b4f0ab857239e313b4f0 feat: add theatrical script formatting
+- e313b4f0ab857239e313b4f0ab857239e313b4f0 add theatrical script formatting
 
   The script format preserves the playwright's original line formatting without alteration:
 

--- a/tests/snapshots/markdown__preserves_tables_without_unwrapping.snap
+++ b/tests/snapshots/markdown__preserves_tables_without_unwrapping.snap
@@ -3,7 +3,7 @@ source: tests/markdown.rs
 expression: result
 ---
 ## New Features
-- 23819342d23062db23819342d23062db23819342 feat: add comparison of Shakespeare's great tragedies
+- 23819342d23062db23819342d23062db23819342 add comparison of Shakespeare's great tragedies
 
   This feature adds a comprehensive overview of the four great tragedies, allowing users to compare key elements across these masterworks of Elizabethan drama.
 

--- a/tests/snapshots/markdown__unwraps_list_items_to_single_lines.snap
+++ b/tests/snapshots/markdown__unwraps_list_items_to_single_lines.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 123
 expression: result
 ---
 ## New Features
-- d662116382ce8f69d662116382ce8f69d6621163 feat: the seven ages of man
+- d662116382ce8f69d662116382ce8f69d6621163 the seven ages of man
 
   All the world's a stage, and all the men and women merely players. They have their exits and their entrances; and one man in his time plays many parts, his acts being seven ages:
 

--- a/tests/snapshots/markdown__unwraps_numbered_lists_to_single_lines.snap
+++ b/tests/snapshots/markdown__unwraps_numbered_lists_to_single_lines.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 146
 expression: result
 ---
 ## New Features
-- eb409319eb0ce5d0eb409319eb0ce5d0eb409319 feat: instructions for wooing fair maidens
+- eb409319eb0ce5d0eb409319eb0ce5d0eb409319 instructions for wooing fair maidens
 
   When wooing a lady of quality, attend to these principles with utmost care and devotion:
 

--- a/tests/snapshots/markdown__unwraps_paragraphs_to_single_lines.snap
+++ b/tests/snapshots/markdown__unwraps_paragraphs_to_single_lines.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/markdown.rs
-assertion_line: 77
 expression: result
 ---
 ## New Features
-- 9d41608a39c39a549d41608a39c39a549d41608a feat: add the quality of mercy soliloquy
+- 9d41608a39c39a549d41608a39c39a549d41608a add the quality of mercy soliloquy
 
   The quality of mercy is not strained. It droppeth as the gentle rain from heaven upon the place beneath. It is twice blessed: it blesseth him that gives and him that takes.
 


### PR DESCRIPTION
closes #94