### PR TITLE
feat: render dependency updates as a table instead of a bulleted list

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -220,6 +220,14 @@ fn strip_conventional_prefix_filter(
     Ok(Value::String(stripped))
 }
 
+fn table_escape_filter(value: &Value, _args: &HashMap<String, Value>) -> tera::Result<Value> {
+    let text = value
+        .as_str()
+        .ok_or_else(|| tera::Error::msg("table_escape filter requires a string value"))?;
+
+    Ok(Value::String(text.replace('|', "\\|")))
+}
+
 fn register_platform_functions(tera: &mut tera::Tera, git_ref: &str, platform: &Platform) {
     let platform = platform.clone();
 
@@ -280,6 +288,7 @@ pub fn render_history(
         "strip_conventional_prefix",
         strip_conventional_prefix_filter,
     );
+    tera.register_filter("table_escape", table_escape_filter);
 
     register_platform_functions(&mut tera, git_ref, platform);
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -111,12 +111,11 @@ pub const DEFAULT_TEMPLATE: &str = r#"{%- macro commit_contributors(commit) -%}
 {%- set filtered_deps = dependencies | prefix(exclude="chore") %}
 {%- if filtered_deps %}
 ## Dependency Updates
-{%- for commit in filtered_deps %}
-- {{ commit_url(sha = commit.hash) }} {{ commit.first_line | strip_conventional_prefix }}{{ self::commit_contributors(commit=commit) }}
-{%- if commit.body %}
 
-{{ commit.body | unwrap | indent(prefix = "  ", first=true) }}
-{%- endif %}
+| Commit | Update | Contributors |
+|--------|--------|--------------|
+{%- for commit in filtered_deps %}
+| {{ commit_url(sha = commit.hash) }} | {{ commit.first_line | strip_conventional_prefix | table_escape }} |{% if commit.contributors %} {{ commit.contributors | mention | join(sep=", ") }}{% endif %} |
 {%- endfor %}
 
 {%- endif %}

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -58,7 +58,13 @@ fn generates_release_note_from_multiple_categories() {
         CommitCategory::Dependencies,
         vec![
             CommitBuilder::new("chore(deps): all that glisters is not gold").build(),
-            CommitBuilder::new("fix(deps): the better part of valor is discretion").build(),
+            CommitBuilder::new("fix(deps): the better part of valor is discretion")
+                .with_contributor_bot("renovate[bot]")
+                .build(),
+            CommitBuilder::new("fix(deps): though this be madness, yet there is method in it")
+                .with_contributor_bot("renovate[bot]")
+                .with_contributor("shakespeare")
+                .build(),
         ],
     );
 
@@ -696,6 +702,35 @@ Each tragedy explores the downfall of a noble figure through their own \
 weaknesses, reflecting the Aristotelian concept of hamartia that \
 Shakespeare so masterfully employed.",
                 )
+                .build(),
+        ],
+    );
+
+    let categorized = CategorizedCommits {
+        by_category,
+        contributors: Vec::new(),
+    };
+    let result = markdown::render_history(
+        &categorized,
+        &Platform::Unknown,
+        "HEAD",
+        TEST_RELEASE_DATE,
+        DEFAULT_TEMPLATE,
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn escapes_table_metacharacters_in_dependency_update_cell() {
+    let mut by_category = HashMap::new();
+
+    by_category.insert(
+        CommitCategory::Dependencies,
+        vec![
+            CommitBuilder::new("fix(deps): bump foo | bar from 1.0.0 to 2.0.0")
+                .with_contributor_bot("renovate[bot]")
                 .build(),
         ],
     );

--- a/tests/snapshots/markdown__escapes_table_metacharacters_in_dependency_update_cell.snap
+++ b/tests/snapshots/markdown__escapes_table_metacharacters_in_dependency_update_cell.snap
@@ -1,0 +1,12 @@
+---
+source: tests/markdown.rs
+expression: result
+---
+## HEAD - November 27, 2025
+## Dependency Updates
+
+| Commit | Update | Contributors |
+|--------|--------|--------------|
+| **`0fb63d0`** | bump foo \| bar from 1.0.0 to 2.0.0 | @renovate[bot] |
+
+*Generated with [release-note](https://github.com/purpleclay/release-note)*

--- a/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
+++ b/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
@@ -28,6 +28,10 @@ expression: result
 
   So quick bright things come to confusion.
 ## Dependency Updates
-- **`7c555da`** the better part of valor is discretion
+
+| Commit | Update | Contributors |
+|--------|--------|--------------|
+| **`7c555da`** | the better part of valor is discretion | @renovate[bot] |
+| **`3f719e1`** | though this be madness, yet there is method in it | @renovate[bot], @shakespeare |
 
 *Generated with [release-note](https://github.com/purpleclay/release-note)*


### PR DESCRIPTION
closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the “Dependency Updates” section to render as a markdown table with clear column headers and one row per dependency update.
  * Each row includes the commit link, update summary, and contributor information when available.
* **Bug Fixes**
  * Improved markdown rendering by escaping table metacharacters in dependency update cells to prevent broken tables.
* **Tests**
  * Expanded dependency update fixtures and added coverage to verify table metacharacter escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->