### PR TITLE
fix: include chore(deps) commits in the dependency updates table

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -108,17 +108,14 @@ pub const DEFAULT_TEMPLATE: &str = r#"{%- macro commit_contributors(commit) -%}
 
 {%- endif %}
 {%- if dependencies %}
-{%- set filtered_deps = dependencies | prefix(exclude="chore") %}
-{%- if filtered_deps %}
 ## Dependency Updates
 
 | Commit | Update | Contributors |
 |--------|--------|--------------|
-{%- for commit in filtered_deps %}
+{%- for commit in dependencies %}
 | {{ commit_url(sha = commit.hash) }} | {{ commit.first_line | strip_conventional_prefix | table_escape }} |{% if commit.contributors %} {{ commit.contributors | mention | join(sep=", ") }}{% endif %} |
 {%- endfor %}
 
-{%- endif %}
 {%- endif %}
 
 *Generated with [release-note](https://github.com/purpleclay/release-note)*"#;

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -85,6 +85,32 @@ fn generates_release_note_from_multiple_categories() {
 }
 
 #[test]
+fn includes_chore_deps_commits_in_dependency_table() {
+    let mut by_category = HashMap::new();
+    by_category.insert(
+        CommitCategory::Dependencies,
+        vec![
+            CommitBuilder::new("chore(deps): bump serde to 1.0.200")
+                .with_contributor_bot("renovate[bot]")
+                .build(),
+        ],
+    );
+    let categorized = CategorizedCommits {
+        by_category,
+        contributors: Vec::new(),
+    };
+    let result = markdown::render_history(
+        &categorized,
+        &Platform::Unknown,
+        "HEAD",
+        TEST_RELEASE_DATE,
+        DEFAULT_TEMPLATE,
+    )
+    .unwrap();
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn displays_contributors_with_github_commit_links() {
     let mut by_category = HashMap::new();
 

--- a/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
+++ b/tests/snapshots/markdown__generates_release_note_from_multiple_categories.snap
@@ -31,6 +31,7 @@ expression: result
 
 | Commit | Update | Contributors |
 |--------|--------|--------------|
+| **`92d570b`** | all that glisters is not gold | |
 | **`7c555da`** | the better part of valor is discretion | @renovate[bot] |
 | **`3f719e1`** | though this be madness, yet there is method in it | @renovate[bot], @shakespeare |
 

--- a/tests/snapshots/markdown__includes_chore_deps_commits_in_dependency_table.snap
+++ b/tests/snapshots/markdown__includes_chore_deps_commits_in_dependency_table.snap
@@ -1,0 +1,12 @@
+---
+source: tests/markdown.rs
+expression: result
+---
+## HEAD - November 27, 2025
+## Dependency Updates
+
+| Commit | Update | Contributors |
+|--------|--------|--------------|
+| **`9b7775b`** | bump serde to 1.0.200 | @renovate[bot] |
+
+*Generated with [release-note](https://github.com/purpleclay/release-note)*


### PR DESCRIPTION
closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency update entries now appear more consistently in the release history table, including updates labeled as chore commits.
  * The dependency list is now rendered directly, preserving commit links, summaries, and contributor details as expected.
* **Tests**
  * Added coverage to verify chore-based dependency updates are included in the generated markdown output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->