### PR TITLE
fix: preserve indented code blocks in the unwrap filter

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -16,6 +16,10 @@ fn is_table_line(line: &str) -> bool {
     (trimmed.starts_with('|') && trimmed.ends_with('|')) || TABLE_SEPARATOR.is_match(trimmed)
 }
 
+fn is_indented(line: &str) -> bool {
+    line.starts_with("    ") || line.starts_with('\t')
+}
+
 fn is_structured_content(para: &str) -> bool {
     para.lines().any(|line| {
         let trimmed = line.trim_start();
@@ -24,8 +28,7 @@ fn is_structured_content(para: &str) -> bool {
             || trimmed.starts_with("+ ")
             || trimmed.starts_with("> ")
             || trimmed.starts_with("```")
-            || trimmed.starts_with("    ")
-            || trimmed.starts_with('\t')
+            || is_indented(line)
             || NUMBERED_LIST.is_match(trimmed)
             || is_table_line(line)
     })
@@ -39,6 +42,7 @@ fn is_continuation_line(line: &str) -> bool {
         && !trimmed.starts_with("+ ")
         && !trimmed.starts_with("> ")
         && !trimmed.starts_with("```")
+        && !is_indented(line)
         && !NUMBERED_LIST.is_match(trimmed)
         && !is_table_line(line)
         && !trimmed.is_empty()
@@ -68,6 +72,15 @@ fn unwrap_structured_content(para: &str) -> String {
         }
 
         if is_table_line(line) {
+            if !current_item.is_empty() {
+                result.push(current_item.join(" "));
+                current_item.clear();
+            }
+            result.push(line.to_string());
+            continue;
+        }
+
+        if is_indented(line) {
             if !current_item.is_empty() {
                 result.push(current_item.join(" "));
                 current_item.clear();

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -379,6 +379,100 @@ These lines must maintain their integrity as written by the immortal bard.",
 }
 
 #[test]
+fn preserves_indented_code_blocks() {
+    let mut by_category = HashMap::new();
+
+    by_category.insert(
+        CommitCategory::Feature,
+        vec![CommitBuilder::new("feat: add indented example")
+            .with_body(
+                "    HAMLET: To be, or not to be, that is the question.\n    OPHELIA: Good my lord, how does your honour for this many a day?",
+            )
+            .build()],
+    );
+
+    let categorized = CategorizedCommits {
+        by_category,
+        contributors: Vec::new(),
+    };
+    let result = markdown::render_history(
+        &categorized,
+        &Platform::Unknown,
+        "HEAD",
+        TEST_RELEASE_DATE,
+        DEFAULT_TEMPLATE,
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn preserves_tab_indented_code_blocks() {
+    let mut by_category = HashMap::new();
+
+    by_category.insert(
+        CommitCategory::Feature,
+        vec![CommitBuilder::new("feat: add tab indented example")
+            .with_body(
+                "\tHAMLET: To be, or not to be, that is the question.\n\tOPHELIA: Good my lord, how does your honour for this many a day?",
+            )
+            .build()],
+    );
+
+    let categorized = CategorizedCommits {
+        by_category,
+        contributors: Vec::new(),
+    };
+    let result = markdown::render_history(
+        &categorized,
+        &Platform::Unknown,
+        "HEAD",
+        TEST_RELEASE_DATE,
+        DEFAULT_TEMPLATE,
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
+fn handles_mixed_prose_and_indented_code_block() {
+    let mut by_category = HashMap::new();
+
+    by_category.insert(
+        CommitCategory::Feature,
+        vec![
+            CommitBuilder::new("feat: document the soliloquy")
+                .with_body(
+                    "The famous soliloquy in its original indented form:
+
+    HAMLET: To be, or not to be, that is the question.
+    OPHELIA: Good my lord, how does your honour for this many a day?
+
+The lines above must be preserved exactly as written.",
+                )
+                .build(),
+        ],
+    );
+
+    let categorized = CategorizedCommits {
+        by_category,
+        contributors: Vec::new(),
+    };
+    let result = markdown::render_history(
+        &categorized,
+        &Platform::Unknown,
+        "HEAD",
+        TEST_RELEASE_DATE,
+        DEFAULT_TEMPLATE,
+    )
+    .unwrap();
+
+    insta::assert_snapshot!(result);
+}
+
+#[test]
 fn preserves_block_quotes_as_is() {
     let mut by_category = HashMap::new();
 

--- a/tests/snapshots/markdown__handles_mixed_prose_and_indented_code_block.snap
+++ b/tests/snapshots/markdown__handles_mixed_prose_and_indented_code_block.snap
@@ -1,0 +1,19 @@
+---
+source: tests/markdown.rs
+expression: result
+---
+## HEAD - November 27, 2025
+
+[**`1`**](#new-features) new feature
+
+## New Features
+- **`47bb817`** document the soliloquy
+
+  The famous soliloquy in its original indented form:
+
+      HAMLET: To be, or not to be, that is the question.
+      OPHELIA: Good my lord, how does your honour for this many a day?
+
+  The lines above must be preserved exactly as written.
+
+*Generated with [release-note](https://github.com/purpleclay/release-note)*

--- a/tests/snapshots/markdown__preserves_indented_code_blocks.snap
+++ b/tests/snapshots/markdown__preserves_indented_code_blocks.snap
@@ -1,0 +1,15 @@
+---
+source: tests/markdown.rs
+expression: result
+---
+## HEAD - November 27, 2025
+
+[**`1`**](#new-features) new feature
+
+## New Features
+- **`c127018`** add indented example
+
+      HAMLET: To be, or not to be, that is the question.
+      OPHELIA: Good my lord, how does your honour for this many a day?
+
+*Generated with [release-note](https://github.com/purpleclay/release-note)*

--- a/tests/snapshots/markdown__preserves_tab_indented_code_blocks.snap
+++ b/tests/snapshots/markdown__preserves_tab_indented_code_blocks.snap
@@ -1,0 +1,15 @@
+---
+source: tests/markdown.rs
+expression: result
+---
+## HEAD - November 27, 2025
+
+[**`1`**](#new-features) new feature
+
+## New Features
+- **`0f05c41`** add tab indented example
+
+  	HAMLET: To be, or not to be, that is the question.
+  	OPHELIA: Good my lord, how does your honour for this many a day?
+
+*Generated with [release-note](https://github.com/purpleclay/release-note)*


### PR DESCRIPTION
closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown parsing to preserve indented code-like lines more reliably.
  * Updated handling so indented blocks are treated as structured content and aren’t merged into continuation text, improving grouping with surrounding prose.

* **Tests**
  * Added snapshot tests verifying space- and tab-indented blocks are retained correctly.
  * Added snapshot coverage for mixed prose plus indented blocks to confirm end-to-end Markdown rendering stays intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->