### PR TITLE
fix: prevent tokens being sent to untrusted hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,25 @@
 # Ignore everything and selectively allow files
 *
 
+!.envrc
 !.gitignore
-!.zed/settings.json
 !.github/**/*
-!scripts/*
+!.zed/settings.json
+!build.rs
+!Cargo.lock
+!Cargo.toml
 !CODE_OF_CONDUCT.md
+!default.nix
+!flake.lock
+!flake.nix
 !LICENSE
 !README.md
-!typos.toml
-
-!.envrc
-!flake.nix
-!flake.lock
-!default.nix
-
-!Cargo.toml
-!Cargo.lock
+!scripts/*
+!SECURITY.md
 !src/**/*.rs
 !tests/*.rs
 !tests/snapshots/*.snap
-!build.rs
+!typos.toml
 target/**/*
 
 # Recurse through sub-directories applying the same patterns

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ strip = "debuginfo"
 
 [dependencies]
 anyhow = "1.0.100"
-clap = { version = "4.5.49", features = ["derive"] }
+clap = { version = "4.5.49", features = ["derive", "env"] }
 env_logger = "0.11"
 git2 = { version = "0.21.0", default-features = false }
 log = "0.4"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Token Trust Model
+
+release-note uses `GITHUB_TOKEN` and `GITLAB_TOKEN` to resolve contributor information via platform APIs. To prevent credential leakage to unintended hosts, tokens are only attached to requests sent to explicitly trusted hosts.
+
+### Always trusted
+
+| Host           | Platform    |
+| -------------- | ----------- |
+| `github.com`   | GitHub SaaS |
+| `*.github.com` | GitHub SaaS |
+| `gitlab.com`   | GitLab SaaS |
+
+### CI environments
+
+When running inside a CI pipeline (`GITHUB_ACTIONS` or `GITLAB_CI`), the platform and API URL are taken from the pipeline's own environment variables. These are considered inherently trusted and tokens are attached normally.
+
+### Self-hosted instances
+
+Self-hosted instances whose hostname begins with `github.` or `gitlab.` (e.g. `github.company.com`, `gitlab.mycorp.io`) require explicit opt-in before a token is attached. Without opt-in, release-note still detects the platform and renders commit URLs, but makes no authenticated API requests. A warning is logged to explain why contributor resolution is degraded.
+
+**Opt-in via environment variable** (comma-separated for multiple hosts):
+
+```sh
+export RELEASE_NOTE_TRUSTED_HOST=github.company.com
+```
+
+**Opt-in via CLI flag** (repeatable):
+
+```sh
+release-note --trusted-host github.company.com
+```
+
+This means that a repository with a remote such as `git@github.evil.com:x/y.git` will have its platform detected for URL rendering, but the user's token will never be sent to that host.
+
+> **Limitation:** hosts that do not follow the `github.*` / `gitlab.*` naming convention (e.g. `git.company.com`) are not recognised as a platform at all and receive neither URL rendering nor contributor resolution, regardless of `RELEASE_NOTE_TRUSTED_HOST`. Support for fully custom domains is not currently implemented.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via a [GitHub Security Advisory](https://github.com/purpleclay/release-note/security/advisories/new).

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,17 @@ struct Args {
     #[arg(value_name = "DIR", long, default_value = ".", verbatim_doc_comment)]
     path: PathBuf,
 
+    /// Trust a host for token attachment (e.g. a self-hosted GitHub Enterprise or GitLab
+    /// instance). Can be repeated or comma-separated. Without this flag, tokens are only
+    /// sent to github.com, *.github.com, and gitlab.com.
+    #[arg(
+        long,
+        value_name = "HOST",
+        value_delimiter = ',',
+        env = "RELEASE_NOTE_TRUSTED_HOST"
+    )]
+    trusted_host: Vec<String>,
+
     /// Enable verbose logging
     #[arg(short, long)]
     verbose: bool,
@@ -75,7 +86,7 @@ fn main() -> Result<()> {
         repo.current_ref()
             .context("failed to determine current reference")
     })?;
-    let platform = Platform::detect(repo.origin_url());
+    let platform = Platform::detect(repo.origin_url(), &args.trusted_host);
 
     if let Ok(Some(mut resolver)) = contributor::ContributorResolver::new(&platform) {
         resolver.resolve_contributors(&mut history);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -20,12 +20,12 @@ pub enum Platform {
 }
 
 impl Platform {
-    pub fn detect(origin_url: Option<&str>) -> Self {
-        let platform = if let Some(platform) = Self::from_ci_env() {
-            platform
+    pub fn detect(origin_url: Option<&str>, trusted_hosts: &[String]) -> Self {
+        let (platform, from_ci) = if let Some(platform) = Self::from_ci_env() {
+            (platform, true)
         } else {
             match origin_url {
-                Some(url) => Self::from_origin_url(url),
+                Some(url) => (Self::from_origin_url(url), false),
                 None => {
                     log::warn!("no origin URL and not running in CI");
                     return Platform::Unknown;
@@ -41,10 +41,13 @@ impl Platform {
                 repo,
                 ..
             } => {
-                let token = std::env::var("GITHUB_TOKEN").ok();
-                if token.is_none() {
-                    log::warn!("no GITHUB_TOKEN found; API requests may be rate limited");
-                }
+                let token = Self::resolve_token(
+                    &url,
+                    from_ci,
+                    trusted_hosts,
+                    "GITHUB_TOKEN",
+                    "no GITHUB_TOKEN found; API requests may be rate limited",
+                );
                 Platform::GitHub {
                     url,
                     api_url,
@@ -60,12 +63,13 @@ impl Platform {
                 project_path,
                 ..
             } => {
-                let token = std::env::var("GITLAB_TOKEN").ok();
-                if token.is_none() {
-                    log::warn!(
-                        "no GITLAB_TOKEN found; contributor resolution requires a token with 'read_user' scope"
-                    );
-                }
+                let token = Self::resolve_token(
+                    &url,
+                    from_ci,
+                    trusted_hosts,
+                    "GITLAB_TOKEN",
+                    "no GITLAB_TOKEN found; contributor resolution requires a token with 'read_user' scope",
+                );
                 Platform::GitLab {
                     url,
                     api_url,
@@ -76,6 +80,25 @@ impl Platform {
             }
             Platform::Unknown => Platform::Unknown,
         }
+    }
+
+    fn resolve_token(
+        url: &str,
+        from_ci: bool,
+        trusted_hosts: &[String],
+        env_var: &str,
+        missing_token_warning: &str,
+    ) -> Option<String> {
+        let host = Self::extract_host_with_protocol(url)
+            .map(|(_, h)| h)
+            .unwrap_or_default();
+        load_trusted_token(
+            from_ci,
+            &host,
+            trusted_hosts,
+            env_var,
+            missing_token_warning,
+        )
     }
 
     fn extract_host_with_protocol(url: &str) -> Option<(String, String)> {
@@ -159,8 +182,12 @@ impl Platform {
                 // Git URLs don't contain protocol info, so we assume HTTPS for web URLs
                 let url = format!("https://{}/{}/{}", host, owner, repo);
                 let protocol = "https";
+                let host_lower = host.to_ascii_lowercase();
 
-                if host.contains("github") {
+                if host_lower == "github.com"
+                    || host_lower.ends_with(".github.com")
+                    || host_lower.starts_with("github.")
+                {
                     let repo_name = repo.split('/').next_back().unwrap_or(&repo);
                     Platform::GitHub {
                         url,
@@ -169,7 +196,7 @@ impl Platform {
                         repo: repo_name.to_string(),
                         token: None,
                     }
-                } else if host.contains("gitlab") {
+                } else if host_lower == "gitlab.com" || host_lower.starts_with("gitlab.") {
                     let project_path = format!("{}/{}", owner, repo);
                     Platform::GitLab {
                         url,
@@ -190,7 +217,8 @@ impl Platform {
     }
 
     fn infer_github_api_url(protocol: &str, host: &str) -> String {
-        if host == "github.com" {
+        let host_lower = host.to_ascii_lowercase();
+        if host_lower == "github.com" || host_lower.ends_with(".github.com") {
             "https://api.github.com".to_string()
         } else {
             format!("{}://{}/api/v3", protocol, host)
@@ -243,6 +271,35 @@ impl Platform {
             )),
             _ => None,
         }
+    }
+}
+
+fn is_trusted_host(host: &str, trusted_hosts: &[String]) -> bool {
+    let host = host.to_ascii_lowercase();
+    host == "github.com"
+        || host.ends_with(".github.com")
+        || host == "gitlab.com"
+        || trusted_hosts.iter().any(|h| h.to_ascii_lowercase() == host)
+}
+
+fn load_trusted_token(
+    from_ci: bool,
+    host: &str,
+    trusted_hosts: &[String],
+    env_var: &str,
+    missing_token_warning: &str,
+) -> Option<String> {
+    if from_ci || is_trusted_host(host, trusted_hosts) {
+        let token = std::env::var(env_var).ok();
+        if token.is_none() {
+            log::warn!("{}", missing_token_warning);
+        }
+        token
+    } else {
+        log::warn!(
+            "host '{host}' is not trusted; set RELEASE_NOTE_TRUSTED_HOST={host} to enable contributor resolution"
+        );
+        None
     }
 }
 

--- a/tests/platform.rs
+++ b/tests/platform.rs
@@ -21,6 +21,7 @@ impl EnvVars {
             "CI_API_GRAPHQL_URL",
             "CI_PROJECT_PATH",
             "GITLAB_TOKEN",
+            "RELEASE_NOTE_TRUSTED_HOST",
         ];
 
         unsafe {
@@ -60,7 +61,7 @@ fn detects_github_from_https_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("https://github.com/owner/repo.git")),
+        Platform::detect(Some("https://github.com/owner/repo.git"), &[]),
         Platform::GitHub {
             url: "https://github.com/owner/repo".to_string(),
             api_url: "https://api.github.com".to_string(),
@@ -76,7 +77,7 @@ fn detects_github_from_ssh_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("git@github.com:owner/repo.git")),
+        Platform::detect(Some("git@github.com:owner/repo.git"), &[]),
         Platform::GitHub {
             url: "https://github.com/owner/repo".to_string(),
             api_url: "https://api.github.com".to_string(),
@@ -92,7 +93,7 @@ fn detects_gitlab_from_https_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("https://gitlab.com/owner/group/repo.git")),
+        Platform::detect(Some("https://gitlab.com/owner/group/repo.git"), &[]),
         Platform::GitLab {
             url: "https://gitlab.com/owner/group/repo".to_string(),
             api_url: "https://gitlab.com/api/v4".to_string(),
@@ -108,7 +109,7 @@ fn detects_gitlab_from_ssh_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("git@gitlab.com:owner/group/repo.git")),
+        Platform::detect(Some("git@gitlab.com:owner/group/repo.git"), &[]),
         Platform::GitLab {
             url: "https://gitlab.com/owner/group/repo".to_string(),
             api_url: "https://gitlab.com/api/v4".to_string(),
@@ -124,7 +125,7 @@ fn detects_github_enterprise_from_https_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("https://github.company.com/owner/repo.git")),
+        Platform::detect(Some("https://github.company.com/owner/repo.git"), &[]),
         Platform::GitHub {
             url: "https://github.company.com/owner/repo".to_string(),
             api_url: "https://github.company.com/api/v3".to_string(),
@@ -140,7 +141,7 @@ fn detects_self_hosted_gitlab_from_https_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("https://gitlab.company.com/owner/repo.git")),
+        Platform::detect(Some("https://gitlab.company.com/owner/repo.git"), &[]),
         Platform::GitLab {
             url: "https://gitlab.company.com/owner/repo".to_string(),
             api_url: "https://gitlab.company.com/api/v4".to_string(),
@@ -156,7 +157,7 @@ fn detects_unknown_for_unrecognized_host() {
     let _clean_env = EnvVars::clear_ci_env();
 
     assert_eq!(
-        Platform::detect(Some("https://git.company.com/owner/repo.git")),
+        Platform::detect(Some("https://git.company.com/owner/repo.git"), &[]),
         Platform::Unknown
     );
 }
@@ -165,7 +166,7 @@ fn detects_unknown_for_unrecognized_host() {
 fn detects_unknown_when_no_origin_url() {
     let _clean_env = EnvVars::clear_ci_env();
 
-    assert_eq!(Platform::detect(None), Platform::Unknown);
+    assert_eq!(Platform::detect(None, &[]), Platform::Unknown);
 }
 
 #[test]
@@ -177,7 +178,7 @@ fn detects_github_from_actions_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitHub {
             url: "https://github.com/owner/repo".to_string(),
             api_url: "https://api.github.com".to_string(),
@@ -197,7 +198,7 @@ fn detects_github_enterprise_from_actions_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitHub {
             url: "https://github.company.com/owner/repo".to_string(),
             api_url: "https://github.company.com/api/v3".to_string(),
@@ -218,7 +219,7 @@ fn detects_github_with_custom_api_url() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitHub {
             url: "https://github.company.com/owner/repo".to_string(),
             api_url: "https://api.github.company.com".to_string(),
@@ -238,7 +239,7 @@ fn detects_gitlab_from_ci_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitLab {
             url: "https://gitlab.com/owner/repo".to_string(),
             api_url: "https://gitlab.com/api/v4".to_string(),
@@ -261,7 +262,7 @@ fn detects_gitlab_with_nested_groups() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitLab {
             url: "https://gitlab.com/owner/group/subgroup/repo".to_string(),
             api_url: "https://gitlab.com/api/v4".to_string(),
@@ -281,7 +282,7 @@ fn detects_self_hosted_gitlab_from_ci_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitLab {
             url: "https://gitlab.company.com/owner/repo".to_string(),
             api_url: "https://gitlab.company.com/api/v4".to_string(),
@@ -306,7 +307,7 @@ fn detects_gitlab_with_custom_api_urls() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitLab {
             url: "https://gitlab.company.com/owner/repo".to_string(),
             api_url: "https://api.gitlab.company.com/v4".to_string(),
@@ -326,7 +327,7 @@ fn ci_detection_takes_precedence_over_url() {
     ]);
 
     assert_eq!(
-        Platform::detect(Some("https://gitlab.com/url-owner/url-repo.git")),
+        Platform::detect(Some("https://gitlab.com/url-owner/url-repo.git"), &[]),
         Platform::GitHub {
             url: "https://github.com/ci-owner/ci-repo".to_string(),
             api_url: "https://api.github.com".to_string(),
@@ -347,7 +348,7 @@ fn detects_github_token_from_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitHub {
             url: "https://github.com/owner/repo".to_string(),
             api_url: "https://api.github.com".to_string(),
@@ -368,13 +369,144 @@ fn detects_gitlab_token_from_env() {
     ]);
 
     assert_eq!(
-        Platform::detect(None),
+        Platform::detect(None, &[]),
         Platform::GitLab {
             url: "https://gitlab.com/owner/repo".to_string(),
             api_url: "https://gitlab.com/api/v4".to_string(),
             graphql_url: "https://gitlab.com/api/graphql".to_string(),
             project_path: "owner/repo".to_string(),
             token: Some("glpat_test_token_456".to_string()),
+        }
+    );
+}
+
+#[test]
+fn withholds_token_for_lookalike_github_host() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(Some("git@github.evil.com:owner/repo.git"), &[]),
+        Platform::GitHub {
+            url: "https://github.evil.com/owner/repo".to_string(),
+            api_url: "https://github.evil.com/api/v3".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            token: None,
+        }
+    );
+}
+
+#[test]
+fn withholds_token_for_notgithub_prefix_host() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(Some("https://notgithub.attacker.com/owner/repo.git"), &[]),
+        Platform::Unknown
+    );
+}
+
+#[test]
+fn attaches_token_for_github_saas_subdomain() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(Some("https://gist.github.com/owner/repo.git"), &[]),
+        Platform::GitHub {
+            url: "https://gist.github.com/owner/repo".to_string(),
+            api_url: "https://api.github.com".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            token: Some("ghp_secret".to_string()),
+        }
+    );
+}
+
+#[test]
+fn withholds_token_for_untrusted_self_hosted_github() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(Some("https://github.company.com/owner/repo.git"), &[]),
+        Platform::GitHub {
+            url: "https://github.company.com/owner/repo".to_string(),
+            api_url: "https://github.company.com/api/v3".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            token: None,
+        }
+    );
+}
+
+#[test]
+fn withholds_token_for_untrusted_self_hosted_gitlab() {
+    let _env = EnvVars::set(&[("GITLAB_TOKEN", "glpat_secret")]);
+
+    assert_eq!(
+        Platform::detect(Some("https://gitlab.company.com/owner/repo.git"), &[]),
+        Platform::GitLab {
+            url: "https://gitlab.company.com/owner/repo".to_string(),
+            api_url: "https://gitlab.company.com/api/v4".to_string(),
+            graphql_url: "https://gitlab.company.com/api/graphql".to_string(),
+            project_path: "owner/repo".to_string(),
+            token: None,
+        }
+    );
+}
+
+#[test]
+fn attaches_token_for_trusted_self_hosted_github() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(
+            Some("https://github.company.com/owner/repo.git"),
+            &["github.company.com".to_string()],
+        ),
+        Platform::GitHub {
+            url: "https://github.company.com/owner/repo".to_string(),
+            api_url: "https://github.company.com/api/v3".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            token: Some("ghp_secret".to_string()),
+        }
+    );
+}
+
+#[test]
+fn attaches_token_for_trusted_host_case_insensitively() {
+    let _env = EnvVars::set(&[("GITHUB_TOKEN", "ghp_secret")]);
+
+    assert_eq!(
+        Platform::detect(
+            Some("https://github.company.com/owner/repo.git"),
+            &["GitHub.Company.com".to_string()],
+        ),
+        Platform::GitHub {
+            url: "https://github.company.com/owner/repo".to_string(),
+            api_url: "https://github.company.com/api/v3".to_string(),
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            token: Some("ghp_secret".to_string()),
+        }
+    );
+}
+
+#[test]
+fn attaches_token_for_trusted_self_hosted_gitlab() {
+    let _env = EnvVars::set(&[("GITLAB_TOKEN", "glpat_secret")]);
+
+    assert_eq!(
+        Platform::detect(
+            Some("https://gitlab.mycorp.io/owner/repo.git"),
+            &["gitlab.mycorp.io".to_string()],
+        ),
+        Platform::GitLab {
+            url: "https://gitlab.mycorp.io/owner/repo".to_string(),
+            api_url: "https://gitlab.mycorp.io/api/v4".to_string(),
+            graphql_url: "https://gitlab.mycorp.io/api/graphql".to_string(),
+            project_path: "owner/repo".to_string(),
+            token: Some("glpat_secret".to_string()),
         }
     );
 }


### PR DESCRIPTION
closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `--trusted-host` option (comma-separated) with `RELEASE_NOTE_TRUSTED_HOST` fallback to control authenticated token usage for self-hosted domains.
* **Bug Fixes**
  * Improved GitHub/GitLab host matching (case-insensitive) to better prevent lookalike domains from being treated as trusted.
  * When not running in CI, authentication is skipped for untrusted hosts (with a warning) to avoid unintended token usage.
* **Documentation**
  * Added a “Token Trust Model” to `SECURITY.md`, detailing token trust scopes and vulnerability reporting.
* **Tests**
  * Expanded coverage for trusted vs. untrusted token attachment and host recognition (including GitHub subdomains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->