### PR TITLE
fix: adopt purpleclay/release-workflows for the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,140 +1,20 @@
 name: release
 on:
   push:
-    tags:
-      - "*.*.*"
+    tags: ["*.*.*"]
+
+permissions: {}
+
 jobs:
-  build:
-    runs-on: ${{ matrix.platform.runs-on }}
-    name: build / ${{ matrix.platform.name }}
-    strategy:
-      matrix:
-        platform:
-          - name: linux_x86_64_musl
-            runs-on: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
-            use-zigbuild: true
-          - name: linux_aarch64_musl
-            runs-on: ubuntu-24.04
-            target: aarch64-unknown-linux-musl
-            use-zigbuild: true
-          - name: darwin_x86_64
-            runs-on: macos-15
-            target: x86_64-apple-darwin
-            use-zigbuild: false
-          - name: darwin_aarch64
-            runs-on: macos-15
-            target: aarch64-apple-darwin
-            use-zigbuild: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform.target }}
-
-      - name: Setup Zig
-        if: ${{ matrix.platform.use-zigbuild }}
-        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
-        with:
-          version: 0.13.0
-
-      - name: Install cargo-zigbuild
-        if: ${{ matrix.platform.use-zigbuild }}
-        run: cargo install cargo-zigbuild
-
-      - name: Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
-      - name: Build with zigbuild
-        if: ${{ matrix.platform.use-zigbuild }}
-        run: cargo zigbuild --locked --release --target ${{ matrix.platform.target }}
-
-      - name: Build with cargo
-        if: ${{ !matrix.platform.use-zigbuild }}
-        run: cargo build --locked --release --target ${{ matrix.platform.target }}
-
-      - name: Archive
-        id: archive
-        shell: bash
-        run: |
-          APP_NAME=$(grep '^name = ' Cargo.toml | head -n1 | cut -d'"' -f2)
-          EXE_SUFFIX=""
-          case ${{ matrix.platform.target }} in
-            *-pc-windows-*)
-              EXE_SUFFIX=".exe"
-              ;;
-          esac;
-          PKG_SUFFIX=".tar.gz";
-          case ${{ matrix.platform.target }} in
-            *-pc-windows-*)
-              PKG_SUFFIX=".zip"
-              ;;
-          esac;
-          PKG_NAME=$APP_NAME-${{ github.ref_name }}-${{ matrix.platform.target }}$PKG_SUFFIX
-          PKG_DIR=archive/$APP_NAME
-          mkdir -p $PKG_DIR
-          cp target/${{ matrix.platform.target }}/release/$APP_NAME$EXE_SUFFIX $PKG_DIR/
-          cp README.md LICENSE $PKG_DIR/
-
-          pushd $PKG_DIR >/dev/null
-          case ${{ matrix.platform.target }} in
-            *-pc-windows-*)
-              7z -y a "${PKG_NAME}" * | tail -2
-              ;;
-            *)
-              tar czf "${PKG_NAME}" *
-              ;;
-          esac;
-          popd >/dev/null
-
-          # Output path to archive for future upload
-          echo "archive-name=${PKG_NAME}" >> $GITHUB_OUTPUT
-          echo "archive-path=${PKG_DIR}/${PKG_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Upload Archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ steps.archive.outputs.archive-name }}
-          path: ${{ steps.archive.outputs.archive-path }}
-          retention-days: 1
-
   release:
-    runs-on: ubuntu-24.04
-    name: release
     permissions:
-      contents: write
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate Release Note
-        id: release_notes
-        run: |
-          echo "note<<EOF" >> $GITHUB_OUTPUT
-          nix run . >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Download Archives
-        id: download
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: archives
-          merge-multiple: true
-
-      - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: ${{ steps.download.outputs.download-path }}/*
-          body: ${{ steps.release_notes.outputs.note }}
-          make_latest: true
+      id-token: write # OIDC identity for Sigstore signing
+      attestations: write # persist attestations
+      contents: write # create the release, upload assets
+      actions: read # list this run's artifacts to resolve their immutable ids
+    uses: purpleclay/release-workflows/.github/workflows/release-rust.yml@c54d2e7971d903a070f1662976a7aa675c508511 # v0.1.0
+    with:
+      bin: release-note
+      targets: '["x86_64-unknown-linux-musl","aarch64-unknown-linux-musl","x86_64-apple-darwin","aarch64-apple-darwin"]'
+      # Keep in sync with the rustToolchain pin in flake.nix
+      toolchain: "1.90.0"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ If you have nix installed, you can run the binary directly from the GitHub repos
 ```sh
 nix run github:purpleclay/release-note -- --help
 ```
+
+## Verifying a release
+
+Every release archive (and `checksums.txt`) is a subject of a SLSA build provenance attestation, signed by the [release-workflows](https://github.com/purpleclay/release-workflows) reusable workflow that built it:
+
+```sh
+gh attestation verify <archive>.tar.gz \
+  --repo purpleclay/release-note \
+  --signer-workflow purpleclay/release-workflows/.github/workflows/release-rust.yml
+```
+
+The `--signer-workflow` check confirms the signing identity belongs to that reusable workflow, not this repository directly — the SLSA Build L3 claim.


### PR DESCRIPTION
closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include signed SLSA build provenance attestations for each archive and `checksums.txt`.
  * Release builds support Linux and macOS on both x86_64 and ARM64 platforms.
* **Documentation**
  * Added a “Verifying a release” section with a `gh attestation verify <archive>.tar.gz` command and guidance on validating the signing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->